### PR TITLE
Add additional resolutions for QHD+ display

### DIFF
--- a/Displays/QHD+/DisplayProductID-144a
+++ b/Displays/QHD+/DisplayProductID-144a
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>DisplayProductName</key>
+  <string>DELL XPS 13 9360 - QHD+</string>
+  <key>DisplayProductID</key>
+  <integer>5194</integer>
+  <key>DisplayVendorID</key>
+  <integer>19728</integer>
+  <key>scale-resolutions</key>
+  <array>
+    <data>AAAMgAAABwg=</data>
+    <data>AAAUAAAAC0AAAAABACAAAA==</data>
+    <data>AAASAAAACiAAAAABACAAAA==</data>
+    <data>AAARgAAACdgAAAABACAAAA==</data>
+    <data>AAARAAAACZAAAAABACAAAA==</data>
+    <data>AAAQAAAACQAAAAABACAAAA==</data>
+    <data>AAAPAAAACHAAAAABACAAAA==</data>
+    <data>AAAMgAAABwgAAAABACAAAA==</data>
+    <data>AAALQAAABlQAAAABACAAAA==</data>
+  </array>
+</dict>
+</plist>

--- a/Displays/profiles.txt
+++ b/Displays/profiles.txt
@@ -6,3 +6,6 @@ Display profile sources & credits:
 - https://github.com/grawlinson/dell-xps-9360/tree/master/display
   https://www.notebookcheck.net/Dell-XPS-13-9360-QHD-i7-7500U-Notebook-Review.181471.0.html
   RXN49_LQ133Z1_01.icm
+
+- DisplayProductID-144a - additional scaled resolutions for QHD+ display
+  copy file to /System/Library/Displays/Contents/Resources/Overrides/DisplayVendorID-4d10/


### PR DESCRIPTION
* Add additional native/scaled resolutions for QHD+ panel (accessible via `rdm`)
```
3200 x 1800
5120 x 2880 (hidpi)
4608 x 2592 (hidpi)
4480 x 2520 (hidpi)
4352 x 2448 (hidpi)
4096 x 2304 (hidpi)
3840 x 2160 (hidpi)
3200 x 1800 (hidpi)
2880 x 1620 (hidpi)